### PR TITLE
fix: Handle unauthenticated users when checking for warnings

### DIFF
--- a/botconfig.example.yml
+++ b/botconfig.example.yml
@@ -139,6 +139,8 @@ logging:
 # Gameplay. This lets you modify certain aspects of the game to better customize the bot for your community.
 gameplay:
   language: en
+  # Whether or not to require players to be identified to NickServ to join the game.
+  # require_nickserv: true
   # Whether or not to allow nightchat, which lets players speak in the main channel during night.
   # If disabled, nobody can speak at night, but idle timers are also paused during the night.
   nightchat: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-antlr4-python3-runtime >= 4.8.0, < 4.9.0
+antlr4-python3-runtime~=4.11.1
 ruamel.yaml >= 0.16.0, < 1.0.0
 requests >= 2.24.0, < 3.0.0
 cryptography >= 38.0.4

--- a/src/defaultsettings.yml
+++ b/src/defaultsettings.yml
@@ -663,6 +663,10 @@ gameplay: &gameplay
       _desc: The language the bot uses in messages and when processing incoming commands.
       _type: str
       _default: en
+    require_nickserv:
+      _desc: Whether or not to require players to be identified to NickServ in order to join the game.
+      _type: bool
+      _default: true
     rules:
       _desc: >
         The rules for this bot, either as an embedded string or a URL, returned by the !rules command.

--- a/src/gamejoin.py
+++ b/src/gamejoin.py
@@ -59,7 +59,7 @@ def join_player(wrapper: MessageDispatcher,
     if wrapper.target is not channels.Main:
         return
 
-    if not wrapper.source.is_fake and not wrapper.source.account:
+    if config.Main.get("gameplay.require_nickserv") and not wrapper.source.is_fake and not wrapper.source.account:
         if forced:
             who.send(messages["account_not_logged_in"].format(wrapper.source), notice=True)
         else:
@@ -89,7 +89,7 @@ def _join_player(wrapper: MessageDispatcher, who: Optional[User] = None, forced=
     temp = wrapper.source.lower()
 
     # don't check unacked warnings on fjoin
-    if wrapper.source is who and db.has_unacknowledged_warnings(temp.account):
+    if wrapper.source is who and temp.account and db.has_unacknowledged_warnings(temp.account):
         wrapper.pm(messages["warn_unacked"])
         return False
 


### PR DESCRIPTION
When the `require_nickserv` option is disabled, users who are not identified to NickServ can join the game. In this case, the user's account is a `_NotLoggedIn` object.

The code that checks for unacknowledged warnings did not account for this, and would pass the `_NotLoggedIn` object to the database, causing a `sqlite3.ProgrammingError`.

This commit fixes the issue by checking if the user has a valid account before checking for unacknowledged warnings.